### PR TITLE
Key management finished

### DIFF
--- a/client/src/key_management.rs
+++ b/client/src/key_management.rs
@@ -1,0 +1,2 @@
+pub mod bundle;
+pub mod key_manager;

--- a/client/src/key_management/bundle.rs
+++ b/client/src/key_management/bundle.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+use libsignal_protocol::*;
+
+pub struct KeyBundleContent {
+    registration_id: u32,
+    device_id: DeviceId,
+    onetime_public_key: Option<(PreKeyId, PublicKey)>,
+    signed_public_key_id: SignedPreKeyId,
+    signed_public_key: PublicKey,
+    signed_signature: Vec<u8>,
+    identity_key: IdentityKey,
+    kyper_key_essentials: Option<(KyberPreKeyId, kem::PublicKey, Vec<u8>)>,
+}
+
+impl KeyBundleContent {
+    pub fn new(
+        registration_id: u32,
+        device_id: DeviceId,
+        onetime_public_key: Option<(PreKeyId, PublicKey)>,
+        signed_public_key: (SignedPreKeyId, PublicKey),
+        signed_signature: Vec<u8>,
+        identity_key: IdentityKey,
+        kyber_public_id_key_signature: Option<(KyberPreKeyId, kem::PublicKey, Vec<u8>)>,
+    ) -> KeyBundleContent {
+        Self {
+            registration_id,
+            device_id,
+            onetime_public_key,
+            signed_public_key_id: signed_public_key.0,
+            signed_public_key: signed_public_key.1,
+            signed_signature,
+            identity_key,
+            kyper_key_essentials: kyber_public_id_key_signature,
+        }
+    }
+    pub fn create_key_bundle(self) -> Result<PreKeyBundle> {
+        let pre_key_bundle = PreKeyBundle::new(
+            self.registration_id,
+            self.device_id,
+            self.onetime_public_key,
+            self.signed_public_key_id,
+            self.signed_public_key,
+            self.signed_signature,
+            self.identity_key,
+        )?;
+        match self.kyper_key_essentials {
+            Some((id, key, sign)) => Ok(PreKeyBundle::with_kyber_pre_key(
+                pre_key_bundle,
+                id,
+                key,
+                sign,
+            )),
+            None => Ok(pre_key_bundle),
+        }
+    }
+}

--- a/client/src/key_management/key_manager.rs
+++ b/client/src/key_management/key_manager.rs
@@ -1,0 +1,211 @@
+use anyhow::Result;
+use libsignal_protocol::*;
+use rand::{CryptoRng, Rng};
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Hash, Eq, PartialEq)]
+pub enum PreKey {
+    Signed,
+    Kyber,
+    OneTime,
+}
+
+pub enum KeyType {
+    KemKey(kem::KeyPair),
+    KeyPair(KeyPair),
+}
+
+pub struct KeyManager {
+    key_incrementer_map: HashMap<PreKey, u32>,
+}
+
+impl KeyManager {
+    pub fn new() -> KeyManager {
+        let mut key_incrementer_map = HashMap::new();
+        key_incrementer_map.insert(PreKey::Signed, 0);
+        key_incrementer_map.insert(PreKey::Kyber, 0);
+        key_incrementer_map.insert(PreKey::OneTime, 0);
+        Self {
+            key_incrementer_map,
+        }
+    }
+
+    fn get_new_key_id(&mut self, key_type: &PreKey) -> u32 {
+        let id = self.key_incrementer_map.get_mut(key_type).unwrap().deref() + 1u32;
+        id - 1
+    }
+
+    async fn compute_signature<R: Rng + CryptoRng>(
+        &self,
+        rng: &mut R,
+        store: &InMemSignalProtocolStore,
+        serialized_public_key: Box<[u8]>,
+    ) -> Result<Box<[u8]>> {
+        Ok(store
+            .get_identity_key_pair()
+            .await?
+            .private_key()
+            .calculate_signature(&serialized_public_key, rng)?)
+    }
+
+    pub async fn generate_key<R: Rng + CryptoRng>(
+        &mut self,
+        mut rng: R,
+        store: &mut InMemSignalProtocolStore,
+        key_type: PreKey,
+    ) -> Result<(KeyType, Option<Box<[u8]>>)> {
+        match key_type {
+            PreKey::Kyber => {
+                let kyper_pre_key_pair = kem::KeyPair::generate(kem::KeyType::Kyber1024);
+                let signature = self
+                    .compute_signature(&mut rng, &store, kyper_pre_key_pair.public_key.serialize())
+                    .await?;
+                let id = self.get_new_key_id(&key_type);
+
+                store
+                    .save_kyber_pre_key(
+                        id.into(),
+                        &KyberPreKeyRecord::new(
+                            id.into(),
+                            Timestamp::from_epoch_millis(
+                                SystemTime::now()
+                                    .duration_since(UNIX_EPOCH)
+                                    .unwrap()
+                                    .as_millis()
+                                    .try_into()?,
+                            ),
+                            &kyper_pre_key_pair,
+                            &signature,
+                        ),
+                    )
+                    .await?;
+
+                Ok((KeyType::KemKey(kyper_pre_key_pair), Some(signature)))
+            }
+            PreKey::Signed => {
+                let signed_pre_key_pair = KeyPair::generate(&mut rng);
+                let signature = self
+                    .compute_signature(&mut rng, &store, signed_pre_key_pair.public_key.serialize())
+                    .await?;
+                let id = self.get_new_key_id(&key_type);
+
+                store
+                    .save_signed_pre_key(
+                        id.into(),
+                        &SignedPreKeyRecord::new(
+                            id.into(),
+                            Timestamp::from_epoch_millis(
+                                SystemTime::now()
+                                    .duration_since(UNIX_EPOCH)
+                                    .unwrap()
+                                    .as_millis()
+                                    .try_into()?,
+                            ),
+                            &signed_pre_key_pair,
+                            &signature,
+                        ),
+                    )
+                    .await?;
+
+                Ok((KeyType::KeyPair(signed_pre_key_pair), Some(signature)))
+            }
+            PreKey::OneTime => {
+                let onetime_pre_key_pair = KeyPair::generate(&mut rng);
+                let id = self.get_new_key_id(&key_type);
+
+                store
+                    .save_pre_key(
+                        id.into(),
+                        &PreKeyRecord::new(id.into(), &onetime_pre_key_pair),
+                    )
+                    .await?;
+
+                Ok((KeyType::KeyPair(onetime_pre_key_pair), None))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod key_manager_tests {
+    use super::*;
+    use core::panic;
+    use rand::rngs::OsRng;
+
+    fn store(reg: u32) -> InMemSignalProtocolStore {
+        let mut rng = OsRng;
+        let p = KeyPair::generate(&mut rng).into();
+        InMemSignalProtocolStore::new(p, reg).unwrap()
+    }
+
+    #[tokio::test]
+    async fn generate_kyper_key() {
+        let rng = OsRng;
+        let mut store = store(0);
+        let mut manager = KeyManager::new();
+        let (key, sign) = manager
+            .generate_key(rng, &mut store, PreKey::Kyber)
+            .await
+            .unwrap();
+
+        assert!(matches!(key, KeyType::KemKey(_)));
+
+        let stored_sign = store
+            .get_kyber_pre_key(store.all_kyber_pre_key_ids().next().unwrap().to_owned())
+            .await
+            .unwrap()
+            .signature()
+            .unwrap();
+
+        assert_eq!(sign.unwrap().to_vec(), stored_sign);
+    }
+
+    #[tokio::test]
+    async fn generate_signed_key() {
+        let rng = OsRng;
+        let mut store = store(0);
+        let mut manager = KeyManager::new();
+        let (key, sign) = manager
+            .generate_key(rng, &mut store, PreKey::Signed)
+            .await
+            .unwrap();
+
+        assert!(matches!(key, KeyType::KeyPair(_)));
+
+        let stored_sign = store
+            .get_signed_pre_key(store.all_signed_pre_key_ids().next().unwrap().to_owned())
+            .await
+            .unwrap()
+            .signature()
+            .unwrap();
+
+        assert_eq!(sign.unwrap().to_vec(), stored_sign);
+    }
+
+    #[tokio::test]
+    async fn generate_onetime_key() {
+        let rng = OsRng;
+        let mut store = store(0);
+        let mut manager = KeyManager::new();
+        let (key, _) = manager
+            .generate_key(rng, &mut store, PreKey::OneTime)
+            .await
+            .unwrap();
+
+        let key_pair = if let KeyType::KeyPair(x) = key {
+            x
+        } else {
+            panic!()
+        };
+
+        let stored_key_pair = store
+            .get_pre_key(store.all_pre_key_ids().next().unwrap().to_owned())
+            .await
+            .unwrap()
+            .key_pair()
+            .unwrap();
+        assert_eq!(key_pair.public_key, stored_key_pair.public_key);
+    }
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,6 +1,7 @@
 mod client;
 mod contact_manager;
 mod encryption;
+mod key_management;
 mod server;
 
 #[tokio::main]


### PR DESCRIPTION
Key management which was in client.rs on the Client struct is now moved to key_management/key_manager.rs. Key management is now done. A struct to support creation of the PreKeyBundle is also added in key_management/bundle.rs