### PR TITLE
Touch up for key endpoints

### DIFF
--- a/client/src/contact_manager.rs
+++ b/client/src/contact_manager.rs
@@ -99,10 +99,9 @@ mod test {
     fn test_cm_add() {
         let mut cm = ContactManager::new();
         let charlie = Uuid::new_v4().to_string();
-        match cm.add_contact(&charlie) {
-            Ok(_) => assert!(true),
-            Err(x) => assert!(false, "{}", x),
-        };
+        if let Err(x) = cm.add_contact(&charlie) {
+            panic!("{}", x)
+        }
     }
 
     #[test]
@@ -110,11 +109,10 @@ mod test {
         let mut cm = ContactManager::new();
         let charlie = Uuid::new_v4().to_string();
 
-        let _ = cm.add_contact(&charlie);
+        cm.add_contact(&charlie);
 
-        match cm.remove_contact(&charlie) {
-            Ok(_) => assert!(true),
-            Err(x) => assert!(false, "{}", x),
+        if let Err(x) = cm.remove_contact(&charlie) {
+            panic!("{}", x)
         }
     }
 
@@ -123,11 +121,11 @@ mod test {
         let mut cm = ContactManager::new();
         let charlie = Uuid::new_v4().to_string();
 
-        let _ = cm.add_contact(&charlie);
+        cm.add_contact(&charlie);
 
         match cm.get_contact(&charlie) {
             Ok(c) => assert!(c.uuid == charlie && c.devices.is_empty()),
-            Err(x) => assert!(false, "{}", x),
+            Err(x) => panic!("{}", x),
         };
     }
 
@@ -136,15 +134,14 @@ mod test {
         let mut cm = ContactManager::new();
         let charlie = Uuid::new_v4().to_string();
 
-        let _ = cm.add_contact(&charlie);
+        cm.add_contact(&charlie);
 
         let mut store = store(1);
         let bundle = create_pre_key_bundle(&mut store, 1, &mut OsRng)
             .await
             .unwrap();
-        match cm.update_contact(&charlie, vec![(1, bundle.try_into().unwrap())]) {
-            Ok(_) => assert!(true),
-            Err(x) => assert!(false, "{}", x),
+        if let Err(x) = cm.update_contact(&charlie, vec![(1, bundle.try_into().unwrap())]) {
+            panic!("{}", x)
         }
 
         assert!(cm.get_contact(&charlie).is_ok(), "Charlie was not ok")

--- a/client/src/key_management/key_manager.rs
+++ b/client/src/key_management/key_manager.rs
@@ -67,20 +67,13 @@ impl KeyManager {
 
                 Ok((KeyType::KeyPair(signed_pre_key_pair), Some(signature)))
             }
-            PreKeyType::OneTime => {
-                let onetime_pre_key_pair = KeyPair::generate(&mut rng);
+            PreKeyType::OneTime | PreKeyType::Identity => {
+                let pre_key_pair = KeyPair::generate(&mut rng);
 
-                self.store_ec_key(store, &key_type, &onetime_pre_key_pair, None)
+                self.store_ec_key(store, &key_type, &pre_key_pair, None)
                     .await?;
 
-                Ok((KeyType::KeyPair(onetime_pre_key_pair), None))
-            }
-            PreKeyType::Identity => {
-                let identity_key = KeyPair::generate(&mut rng);
-
-                self.store_ec_key(store, &key_type, &identity_key, None);
-
-                Ok((KeyType::KeyPair(identity_key), None))
+                Ok((KeyType::KeyPair(pre_key_pair), None))
             }
         }
     }

--- a/server/database/init.sql
+++ b/server/database/init.sql
@@ -65,7 +65,6 @@ CREATE TABLE one_time_pre_key_store (
     owner     INTEGER NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
     key_id      TEXT NOT NULL,
     public_key  bytea NOT NULL,
-    signature   bytea NOT NULL,
     UNIQUE(owner, key_id)
 );
 

--- a/server/src/account.rs
+++ b/server/src/account.rs
@@ -10,6 +10,13 @@ pub struct Account {
     pub pni: Option<String>,
     pub auth_token: String,
     pub identity_key: IdentityKey,
+    pub attributes: AccountAttributes,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct AccountAttributes {
+    pub aci_registration_id: i64,
+    pub pni_registration_id: i64,
 }
 
 impl Account {

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -4,7 +4,7 @@ use crate::account::{Account, Device};
 use anyhow::Result;
 use axum::async_trait;
 use common::signal_protobuf::Envelope;
-use common::web_api::{DevicePreKeyBundle, UploadSignedPreKey};
+use common::web_api::{DevicePreKeyBundle, UploadPreKey, UploadSignedPreKey};
 use libsignal_core::{Aci, Pni, ProtocolAddress, ServiceId};
 use sqlx::Transaction;
 
@@ -66,12 +66,12 @@ pub trait SignalDatabase: Clone {
     async fn store_key_bundle(
         &self,
         data: DevicePreKeyBundle,
-        address: ProtocolAddress,
+        address: &ProtocolAddress,
     ) -> Result<()>;
 
     /// Get the keys that are needed to start a conversation with the device that
     /// corrosponds to the given [ProtocolAddress].
-    async fn get_key_bundle(&self, address: ProtocolAddress) -> Result<DevicePreKeyBundle>;
+    async fn get_key_bundle(&self, address: &ProtocolAddress) -> Result<DevicePreKeyBundle>;
 
     /// Get how many keys are left until a last resort key is used instead of
     /// a one time prekey. More keys should be uploaded when this value is below
@@ -81,11 +81,11 @@ pub trait SignalDatabase: Clone {
     /// Store new one time prekeys to avoid running out.
     async fn store_one_time_pre_keys(
         &self,
-        otpks: Vec<UploadSignedPreKey>,
+        otpks: Vec<UploadPreKey>,
         owner: ProtocolAddress,
     ) -> Result<()>;
 
     /// Get a one time prekey so that you can start a conversation with the
     /// device that is associated with the given [ProtocolAddress].
-    async fn get_one_time_pre_key(&self, owner: ProtocolAddress) -> Result<UploadSignedPreKey>;
+    async fn get_one_time_pre_key(&self, owner: &ProtocolAddress) -> Result<UploadPreKey>;
 }

--- a/server/src/in_memory_db.rs
+++ b/server/src/in_memory_db.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use axum::async_trait;
 use common::pre_key::PreKeyType;
 use common::signal_protobuf::Envelope;
-use common::web_api::{DevicePreKeyBundle, UploadSignedPreKey};
+use common::web_api::{DevicePreKeyBundle, UploadPreKey, UploadSignedPreKey};
 use libsignal_core::{Aci, DeviceId, Pni, ProtocolAddress, ServiceId};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
@@ -164,11 +164,11 @@ impl SignalDatabase for InMemorySignalDatabase {
     async fn store_key_bundle(
         &self,
         data: DevicePreKeyBundle,
-        owner_address: ProtocolAddress,
+        owner_address: &ProtocolAddress,
     ) -> Result<()> {
         todo!()
     }
-    async fn get_key_bundle(&self, address: ProtocolAddress) -> Result<DevicePreKeyBundle> {
+    async fn get_key_bundle(&self, address: &ProtocolAddress) -> Result<DevicePreKeyBundle> {
         todo!()
     }
 
@@ -187,16 +187,13 @@ impl SignalDatabase for InMemorySignalDatabase {
 
     async fn store_one_time_pre_keys(
         &self,
-        otpks: Vec<UploadSignedPreKey>,
+        otpks: Vec<UploadPreKey>,
         owner_address: ProtocolAddress,
     ) -> Result<()> {
         todo!()
     }
 
-    async fn get_one_time_pre_key(
-        &self,
-        owner_address: ProtocolAddress,
-    ) -> Result<UploadSignedPreKey> {
+    async fn get_one_time_pre_key(&self, owner_address: &ProtocolAddress) -> Result<UploadPreKey> {
         todo!()
     }
 }

--- a/server/src/managers/key_manager.rs
+++ b/server/src/managers/key_manager.rs
@@ -1,8 +1,175 @@
+use axum::http::StatusCode;
+use common::web_api::{PreKeyResponse, PreKeyResponseItem, SetKeyRequest};
+use libsignal_core::{DeviceId, ProtocolAddress, ServiceId};
+use libsignal_protocol::PreKeyBundle;
+use sha2::{Digest, Sha256};
+
+use crate::{api_error::ApiError, database::SignalDatabase};
+
 #[derive(Debug, Clone)]
 pub struct KeyManager {}
 
 impl KeyManager {
     pub fn new() -> Self {
         Self {}
+    }
+    async fn handle_put_keys<S: SignalDatabase>(
+        database: S,
+        address: &ProtocolAddress,
+        bundle: SetKeyRequest,
+    ) -> Result<(), ApiError> {
+        todo!()
+    }
+
+    async fn handle_get_keys<S: SignalDatabase>(
+        database: S,
+        address_and_registration_ids: Vec<(ProtocolAddress, u32)>,
+    ) -> Result<PreKeyResponse, ApiError> {
+        async fn get_key<S: SignalDatabase>(
+            database: &S,
+            service_id: &ServiceId,
+            device_id: DeviceId,
+            registration_id: u32,
+            address: ProtocolAddress,
+        ) -> Result<PreKeyResponseItem, ApiError> {
+            let bundle = database
+                .get_key_bundle(&address)
+                .await
+                .map_err(|_| ApiError {
+                    status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                    message: "Could not fetch user key bundle".into(),
+                })?;
+
+            let (pq_pre_key, signed_pre_key) = match service_id {
+                ServiceId::Aci(_) => (bundle.aci_pq_pre_key, bundle.aci_signed_pre_key),
+                ServiceId::Pni(_) => (bundle.pni_pq_pre_key, bundle.pni_signed_pre_key),
+            };
+
+            let prekey = database
+                .get_one_time_pre_key(&address)
+                .await
+                .map_err(|_| ApiError {
+                    status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                    message: "Could not fetch user pre key".into(),
+                })?;
+
+            Ok(PreKeyResponseItem::new(
+                device_id,
+                registration_id,
+                prekey,
+                pq_pre_key,
+                signed_pre_key,
+            ))
+        }
+
+        let mut keys = Vec::new();
+        let mut last_service_id = None;
+        for (address, registration_id) in address_and_registration_ids {
+            let service_id =
+                ServiceId::parse_from_service_id_string(address.name()).ok_or_else(|| {
+                    ApiError {
+                        status_code: StatusCode::BAD_REQUEST,
+                        message: format!("Invalid name in protocol address: {}", address.name()),
+                    }
+                })?;
+            keys.push(
+                get_key(
+                    &database,
+                    &service_id,
+                    address.device_id(),
+                    registration_id,
+                    address,
+                )
+                .await?,
+            );
+            last_service_id = Some(service_id);
+        }
+
+        let account = database
+            .get_account(&last_service_id.ok_or_else(|| ApiError {
+                status_code: StatusCode::BAD_REQUEST,
+                message: "You must request atleast one device".into(),
+            })?)
+            .await
+            .map_err(|_| ApiError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                message: "Could not fetch user account".into(),
+            })?;
+
+        let identity_key = match last_service_id.unwrap() {
+            ServiceId::Aci(_) => account.aci_identity_key(),
+            ServiceId::Pni(_) => account.pni_identity_key(),
+        };
+
+        Ok(PreKeyResponse::new(identity_key, keys))
+    }
+
+    // The Signal endpoint /v2/keys/check says that a u64 id is needed, however their ids, such as
+    // KyperPreKeyID only supports u32. Here only a u32 is used and therefore only a 4 byte size
+    // instead of the sugested u64.
+    async fn handle_post_keycheck<S: SignalDatabase>(
+        database: S,
+        address: ProtocolAddress, // Should instead take an Authenticated Device when implemented
+        usr_digest: [u8; 32],
+    ) -> Result<bool, ApiError> {
+        let service_id =
+            ServiceId::parse_from_service_id_string(address.name()).ok_or_else(|| ApiError {
+                status_code: todo!(),
+                message: format!("Bad protocol address: {}", address),
+            })?;
+        let account = database
+            .get_account(&service_id)
+            .await
+            .map_err(|_| ApiError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                message: "Could not fetch user account".into(),
+            })?;
+        let bundle = database
+            .get_key_bundle(&address)
+            .await
+            .map_err(|_| ApiError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                message: "Could not fetch user key bundle".into(),
+            })?;
+
+        let mut digest = Sha256::new();
+        match service_id {
+            ServiceId::Aci(_) => {
+                digest.update(
+                    account
+                        .aci_identity_key()
+                        .public_key()
+                        .public_key_bytes()
+                        .map_err(|_| ApiError {
+                            status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                            message: "Could not convert key to bytes".into(),
+                        })?,
+                );
+                digest.update(bundle.aci_signed_pre_key.key_id.to_be_bytes());
+                digest.update(&bundle.aci_signed_pre_key.public_key);
+                digest.update(bundle.aci_pq_pre_key.key_id.to_be_bytes());
+                digest.update(&bundle.aci_pq_pre_key.public_key);
+            }
+            ServiceId::Pni(_) => {
+                digest.update(
+                    account
+                        .pni_identity_key()
+                        .public_key()
+                        .public_key_bytes()
+                        .map_err(|_| ApiError {
+                            status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                            message: "Could not convert key to bytes".into(),
+                        })?,
+                );
+                digest.update(bundle.pni_signed_pre_key.key_id.to_be_bytes());
+                digest.update(&bundle.pni_signed_pre_key.public_key);
+                digest.update(bundle.pni_pq_pre_key.key_id.to_be_bytes());
+                digest.update(&bundle.pni_pq_pre_key.public_key);
+            }
+        }
+
+        let server_digest: [u8; 32] = digest.finalize().into();
+
+        Ok(server_digest == usr_digest)
     }
 }


### PR DESCRIPTION
Reduced amount of params since we are certain that the name in protocol address is a [ServiceId].
Set comment for future reminder to change it again when authenticated devices are implemented.