### PR TITLE
Added verification to get keys when asking as an auth device

### DIFF
--- a/client/src/contact_manager.rs
+++ b/client/src/contact_manager.rs
@@ -55,7 +55,7 @@ impl ContactManager {
             ));
         }
         self.contacts
-            .insert(service_id.clone(), Contact::new(*service_id, device_id));
+            .insert(*service_id, Contact::new(*service_id, device_id));
         Ok(())
     }
 

--- a/client/src/encryption.rs
+++ b/client/src/encryption.rs
@@ -105,7 +105,7 @@ pub mod test {
 
         let pre_key_bundle = PreKeyBundle::new(
             store.get_local_registration_id().await?, // the users unique id
-            device_id.into(),
+            device_id,
             Some((pre_key_id.into(), pre_key_pair.public_key)),
             signed_pre_key_id.into(),
             signed_pre_key_pair.public_key,

--- a/client/src/test_utils/user.rs
+++ b/client/src/test_utils/user.rs
@@ -11,7 +11,7 @@ pub fn new_aci() -> Aci {
 }
 
 pub fn new_pni() -> Pni {
-    Pni::from(new_uuid()).into()
+    Pni::from(new_uuid())
 }
 
 pub fn new_device_id() -> DeviceId {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -358,7 +358,7 @@ async fn post_keycheck_endpoint(
             check_keys_request.user_digest,
         )
         .await?
-        .then(|| ())
+        .then_some(())
         .ok_or_else(|| ApiError {
             status_code: StatusCode::CONFLICT,
             message: "".into(),

--- a/server/src/test_utils/user.rs
+++ b/server/src/test_utils/user.rs
@@ -83,7 +83,7 @@ pub fn new_aci() -> Aci {
 }
 
 pub fn new_pni() -> Pni {
-    Pni::from(new_uuid()).into()
+    Pni::from(new_uuid())
 }
 
 pub fn new_device_id() -> DeviceId {


### PR DESCRIPTION
Closes #130
This pull request includes several changes to improve the handling of `PreKeyResponse` and account verification in the `KeyManager`. The most important changes include adding a new implementation to convert `PreKeyResponse` to `PreKeyBundle`, updating the `KeyManager` to verify accounts through the authentication device, and modifying test cases to ensure proper account addition.

Enhancements to `PreKeyResponse` handling:

* [`common/src/web_api/mod.rs`](diffhunk://#diff-3b18665521efc07fd3a4f42e33271273680bb88ad15f5d3187d746d9c430003cR369-R412): Added an implementation to convert `PreKeyResponse` to a vector of `PreKeyBundle` with detailed error handling for key decoding.

Account verification improvements:

* [`server/src/managers/key_manager.rs`](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2L134-R140): Updated the `KeyManager` to verify accounts through the authentication device by retrieving the account from the database and handling potential errors.

Test case modifications:

* [`server/src/managers/key_manager.rs`](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2R329): Modified test cases to include the addition of accounts to the database before handling key requests, ensuring proper setup for authentication devices. [[1]](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2R329) [[2]](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2R412)
* [`server/src/managers/key_manager.rs`](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2L286-R302): Replaced the use of `Uuid::new_v4()` with `new_uuid()` and `new_pni()` in the `new_account_from_identity_key` function to standardize account creation in tests.

These changes collectively enhance the robustness and reliability of the `KeyManager` and `PreKeyResponse` handling in the codebase.