### PR TITLE
Fixup on GET/PUT keys endpoints

### DIFF
--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -94,7 +94,10 @@ pub trait SignalDatabase: Clone + Send + Sync + 'static {
 
     /// Get a one time prekey so that you can start a conversation with the
     /// device that is associated with the given [ProtocolAddress].
-    async fn get_one_time_ec_pre_key(&self, owner: &ProtocolAddress) -> Result<UploadPreKey>;
+    async fn get_one_time_ec_pre_key(
+        &self,
+        owner: &ProtocolAddress,
+    ) -> Result<Option<UploadPreKey>>;
 
     async fn get_one_time_pq_pre_key(&self, owner: &ProtocolAddress) -> Result<UploadSignedPreKey>;
 

--- a/server/src/managers/key_manager.rs
+++ b/server/src/managers/key_manager.rs
@@ -376,7 +376,10 @@ mod key_manager_tests {
             device_bundle[0].registration_id(),
             target_device.registration_id()
         );
-        assert_eq!(device_bundle[0].pre_key().clone(), one_time[0]);
+        assert_eq!(
+            device_bundle[0].pre_key().clone(),
+            Some(one_time[0].clone())
+        );
         assert_eq!(
             device_bundle[0].signed_pre_key().clone(),
             key_bundle.pni_signed_pre_key
@@ -454,7 +457,10 @@ mod key_manager_tests {
             device_bundle[0].registration_id(),
             target_device.registration_id()
         );
-        assert_eq!(device_bundle[0].pre_key().clone(), one_time[0]);
+        assert_eq!(
+            device_bundle[0].pre_key().clone(),
+            Some(one_time[0].clone())
+        );
         assert_eq!(
             device_bundle[0].signed_pre_key().clone(),
             key_bundle.pni_signed_pre_key
@@ -468,7 +474,10 @@ mod key_manager_tests {
             device_bundle[1].registration_id(),
             device2.registration_id()
         );
-        assert_eq!(device_bundle[1].pre_key().clone(), one_time[0]);
+        assert_eq!(
+            device_bundle[1].pre_key().clone(),
+            Some(one_time[0].clone())
+        );
         assert_eq!(
             device_bundle[1].signed_pre_key().clone(),
             key_bundle.pni_signed_pre_key
@@ -537,7 +546,7 @@ mod key_manager_tests {
             .await
             .unwrap();
 
-        assert_eq!(prekey[0], prekey_db);
+        assert_eq!(Some(prekey[0].clone()), prekey_db);
         assert_eq!(signed_pre_key, signed_pre_key_db);
         assert_eq!(pq_pre_key, pq_pre_key_db);
         assert_eq!(pq_last_resort_pre_key, pq_last_resort_pre_key_db);

--- a/server/src/postgres.rs
+++ b/server/src/postgres.rs
@@ -648,7 +648,10 @@ impl SignalDatabase for PostgresDatabase {
         Ok(())
     }
 
-    async fn get_one_time_ec_pre_key(&self, owner: &ProtocolAddress) -> Result<UploadPreKey> {
+    async fn get_one_time_ec_pre_key(
+        &self,
+        owner: &ProtocolAddress,
+    ) -> Result<Option<UploadPreKey>> {
         sqlx::query!(
             r#"
             WITH key AS
@@ -675,11 +678,16 @@ impl SignalDatabase for PostgresDatabase {
         )
         .fetch_one(&self.pool)
         .await
-        .map(|row| UploadPreKey {
-            key_id: row.key_id.parse().unwrap(),
-            public_key: row.public_key.into(),
+        .map(|row| {
+            Some(UploadPreKey {
+                key_id: row.key_id.parse().unwrap(),
+                public_key: row.public_key.into(),
+            })
         })
-        .map_err(|err| err.into())
+        .or_else(|err| match err {
+            sqlx::Error::RowNotFound => Ok(None), // If there is no one-time prekey
+            _err => Err(_err.into()),
+        })
     }
 
     async fn get_one_time_pq_pre_key(&self, owner: &ProtocolAddress) -> Result<UploadSignedPreKey> {
@@ -1333,7 +1341,7 @@ mod db_tests {
         db.store_one_time_ec_pre_keys(otpks.clone(), &address)
             .await
             .unwrap();
-        let retrieved_key = db.get_one_time_ec_pre_key(&address).await.unwrap();
+        let retrieved_key = db.get_one_time_ec_pre_key(&address).await.unwrap().unwrap();
         db.delete_account(&account.aci().into()).await.unwrap();
 
         assert_eq!(otpks, vec![retrieved_key])

--- a/server/src/test_utils/websocket.rs
+++ b/server/src/test_utils/websocket.rs
@@ -104,7 +104,7 @@ impl SignalDatabase for MockDB {
         todo!()
     }
 
-    async fn get_one_time_ec_pre_key(&self, _: &ProtocolAddress) -> Result<UploadPreKey> {
+    async fn get_one_time_ec_pre_key(&self, _: &ProtocolAddress) -> Result<Option<UploadPreKey>> {
         todo!()
     }
 


### PR DESCRIPTION
This pull request introduces several changes to support optional `UploadPreKey` in various parts of the codebase. The changes include modifications to data structures, database interfaces, and related tests to handle the new optionality of `UploadPreKey`.

### Changes to data structures:

* [`common/src/web_api/mod.rs`](diffhunk://#diff-3b18665521efc07fd3a4f42e33271273680bb88ad15f5d3187d746d9c430003cL331-R331): Updated `PreKeyResponseItem` to make `pre_key` an `Option<UploadPreKey>` and adjusted related methods accordingly. [[1]](diffhunk://#diff-3b18665521efc07fd3a4f42e33271273680bb88ad15f5d3187d746d9c430003cL331-R331) [[2]](diffhunk://#diff-3b18665521efc07fd3a4f42e33271273680bb88ad15f5d3187d746d9c430003cL340-R340) [[3]](diffhunk://#diff-3b18665521efc07fd3a4f42e33271273680bb88ad15f5d3187d746d9c430003cL358-R358)

### Changes to database interfaces:

* [`server/src/database.rs`](diffhunk://#diff-805c83779fd625ae8d65cb912b1233551760a669c7d59c3f303a325c0da9fc9bL97-R100): Modified the `get_one_time_ec_pre_key` method in the `SignalDatabase` trait to return `Result<Option<UploadPreKey>>` instead of `Result<UploadPreKey>`.
* [`server/src/postgres.rs`](diffhunk://#diff-4e5e9ca2a6b1969a2172a86db358be42c081c7aab43b44ce7a579046b5cc1109L651-R654): Updated the `get_one_time_ec_pre_key` method implementation in `PostgresDatabase` to handle the optional `UploadPreKey`. [[1]](diffhunk://#diff-4e5e9ca2a6b1969a2172a86db358be42c081c7aab43b44ce7a579046b5cc1109L651-R654) [[2]](diffhunk://#diff-4e5e9ca2a6b1969a2172a86db358be42c081c7aab43b44ce7a579046b5cc1109L678-R690)
* [`server/src/test_utils/websocket.rs`](diffhunk://#diff-187644da438d65265122aaa88936ccf8ff56858e3a4f103dd182ef2c62c7c61aL107-R107): Updated the `get_one_time_ec_pre_key` method in `MockDB` to return `Result<Option<UploadPreKey>>`.

### Changes to key manager:

* [`server/src/managers/key_manager.rs`](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2L29-L54): Refactored `KeyManager` to handle optional `UploadPreKey` in various methods, including verification and storage of prekeys. [[1]](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2L29-L54) [[2]](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2L65-L68) [[3]](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2L79)

### Changes to tests:

* [`common/src/web_api/mod.rs`](diffhunk://#diff-3b18665521efc07fd3a4f42e33271273680bb88ad15f5d3187d746d9c430003cL448-R455): Adjusted tests to accommodate the optional `UploadPreKey` in `PreKeyResponseItem`.
* [`server/src/managers/key_manager.rs`](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2L365-R382): Updated tests to handle the optional `UploadPreKey` in `KeyManager`. [[1]](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2L365-R382) [[2]](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2L443-R463) [[3]](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2L457-R480) [[4]](diffhunk://#diff-a875b42768d5a1880173d18aab8f37a49ffb48356ff9d1b26bf9e41bef1025a2L526-R549)
* [`server/src/postgres.rs`](diffhunk://#diff-4e5e9ca2a6b1969a2172a86db358be42c081c7aab43b44ce7a579046b5cc1109L1336-R1344): Modified database tests to handle the optional `UploadPreKey`.