### PR TITLE
Update identity_type to identity

### DIFF
--- a/client/src/server.rs
+++ b/client/src/server.rs
@@ -138,7 +138,7 @@ impl SignalServerAPI for SignalServer {
         &mut self,
         pre_key_bundle: SetKeyRequest,
     ) -> Result<(), SignalClientError> {
-        let uri = format!("{}?identity_type=aci", KEY_BUNDLE_URI);
+        let uri = format!("{}?identity=aci", KEY_BUNDLE_URI);
         self.make_request(ReqType::Put(json!(pre_key_bundle)), uri)
             .await
             .map_err(|err| SignalClientError::KeyError(err.to_string()))?;


### PR DESCRIPTION
Since the server looks for the "identity" parameter, it also has to be "identity" on the client side. The issue is that the client names the variable "identity_type"

This fixes that