### PR TITLE
Signal Headers and Compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-dup"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +886,7 @@ dependencies = [
  "derive_more",
  "display",
  "dotenv",
+ "flate2",
  "futures-util",
  "http-client",
  "libsignal-core",
@@ -1044,6 +1058,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -1524,6 +1547,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -4651,11 +4684,15 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
 dependencies = [
+ "async-compression",
  "bitflags 2.6.0",
  "bytes 1.8.0",
+ "futures-core",
  "http 1.1.0",
  "http-body",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ cargo run
 ```
 As an example, two clients should then be created and messages between them will be send.
 
+### TLS Configuration
+If you do not want to use HTTPS and WSS you can run the server and client with `--no-tls` and then they will just communicate over HTTP and WS
+
 ## Clean up
 ### Resetting the server database
 1. Go into `server`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ SERVER_ADDRESS=127.0.0.1
 HTTPS_PORT=443
 HTTP_PORT=80
 ```
+
+if you are on linux and do not want to sudo the program, you can change the HTTPS and HTTP ports to your liking.
+
 3. Go into `server/cert`
 4. Generate certificates by running the following
 ```zsh

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ DATABASE_URL=postgres://root:root@127.0.0.1:5432/signal_db
 DATABASE_URL_TEST=postgres://test:test@127.0.0.1:3306/signal_db_test
 REDIS_URL=redis://127.0.0.1:6379
 SERVER_ADDRESS=127.0.0.1
-HTTPS_PORT=4444
-HTTP_PORT=8888
+HTTPS_PORT=443
+HTTP_PORT=80
 ```
 3. Go into `server/cert`
 4. Generate certificates by running the following
@@ -36,7 +36,8 @@ cargo run
 1. Go into `client`
 2. Create a file called `.env` with the following content
 ```
-SERVER_URL=https://localhost:4444
+HTTPS_SERVER_URL=https://localhost:443
+HTTP_SERVER_URL=http://localhost:80
 DATABASE_URL=sqlite://./client/client_db/dev.db
 DATABASE_URL_TEST=sqlite::memory:
 CERT_PATH=../server/cert/rootCA.crt

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -34,6 +34,7 @@ rustls = { version = "0.23.15", features = ["ring"] }
 rustls-pemfile = "2.2.0"
 derive_more = { version = "1.0.0", features = ["display", "error", "from"] }
 display = "0.1.2"
+flate2 = "1.0.35"
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -251,7 +251,7 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
         ))
     }
 
-    pub async fn disconnect(&mut self){
+    pub async fn disconnect(&mut self) {
         self.server_api.disconnect().await;
     }
 
@@ -505,9 +505,6 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
         Ok(device_ids)
     }
 }
-
-
-
 
 fn decode_ciphertext(
     bytes: Vec<u8>,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -258,9 +258,15 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
     pub async fn send_message(
         &mut self,
         message: &str,
-        service_id: &ServiceId,
         alias: &str,
     ) -> Result<()> {
+        let service_id = self
+            .storage
+            .device
+            .get_service_id_by_nickname(alias)
+            .await
+            .map_err(DatabaseError::from)?;
+
         let content = Content::builder()
             .data_message(
                 DataMessage::builder()
@@ -275,28 +281,28 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
 
         let timestamp = SystemTime::now();
 
-        // Update the contact.
-        let to = match self.contact_manager.get_contact(service_id) {
+        /*// Update the contact.
+        let to = match self.contact_manager.get_contact(&service_id) {
             Err(_) => {
-                self.add_contact(alias, service_id)
+                self.add_contact(alias, &service_id)
                     .await
                     .expect("Can add contact that does not exist yet");
 
-                let device_ids = self.get_new_device_ids(service_id).await?;
+                let device_ids = self.get_new_device_ids(&service_id).await?;
 
                 self.update_contact(alias, device_ids).await?;
 
                 self.contact_manager
-                    .get_contact(service_id)
-                    .expect("Can get contact that was just added.")
+                    .get_contact(&service_id)
+                    .expect("Can get contact")
             }
             Ok(contact) => contact,
-        };
+        };*/
 
         let msgs = encrypt(
             &mut self.storage.protocol_store.identity_key_store,
             &mut self.storage.protocol_store.session_store,
-            to,
+            self.contact_manager.get_contact(&service_id)?,
             pad_message(content.encode_to_vec().as_ref()).as_ref(),
             timestamp,
         )
@@ -324,20 +330,20 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
                     content: BASE64_STANDARD.encode(msg.1.serialize()),
                 })
                 .collect(),
-            online: false,
-            urgent: true,
+            online: true,
+            urgent: false,
             timestamp: timestamp
                 .duration_since(UNIX_EPOCH)
                 .expect("can get the time since epoch")
                 .as_secs(),
         };
 
-        match self.server_api.send_msg(&msgs, service_id).await {
+        match self.server_api.send_msg(&msgs, &service_id).await {
             Ok(_) => Ok(()),
             Err(_) => {
-                let device_ids = self.get_new_device_ids(service_id).await?;
+                let device_ids = self.get_new_device_ids(&service_id).await?;
                 self.update_contact(alias, device_ids).await?;
-                self.server_api.send_msg(&msgs, service_id).await
+                self.server_api.send_msg(&msgs, &service_id).await
             }
         }
     }
@@ -417,25 +423,36 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
     }
 
     pub async fn add_contact(&mut self, alias: &str, service_id: &ServiceId) -> Result<()> {
+        if self.contact_manager.get_contact(&service_id).is_ok(){
+            return Ok(());
+        }
         self.contact_manager
             .add_contact(&service_id)
             .map_err(SignalClientError::ContactManagerError)?;
-        let contact = self
-            .contact_manager
-            .get_contact(&service_id)
-            .map_err(SignalClientError::ContactManagerError)?;
 
+        
+        
+        let contact = self
+        .contact_manager
+        .get_contact(&service_id)
+        .map_err(SignalClientError::ContactManagerError)?;
+    
         self.storage
             .device
             .store_contact(contact)
             .await
             .map_err(DatabaseError::from)?;
-
+    
+        
         self.storage
-            .device
-            .insert_service_id_for_nickname(alias, &service_id)
-            .await
-            .map_err(|err| DatabaseError::Custom(Box::new(err)).into())
+        .device
+        .insert_service_id_for_nickname(alias, &service_id)
+        .await
+        .map_err(|err| SignalClientError::DatabaseError(DatabaseError::Custom(Box::new(err))))?;
+    
+        let device_ids = self.get_new_device_ids(&service_id).await?;
+        self.update_contact(alias, device_ids).await
+
     }
 
     pub async fn remove_contact(&mut self, alias: &str) -> Result<()> {
@@ -457,7 +474,7 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
             .map_err(|err| DatabaseError::Custom(Box::new(err)).into())
     }
 
-    pub async fn update_contact(&mut self, alias: &str, device_ids: Vec<DeviceId>) -> Result<()> {
+    async fn update_contact(&mut self, alias: &str, device_ids: Vec<DeviceId>) -> Result<()> {
         let service_id = self
             .storage
             .device

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -277,24 +277,6 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
 
         let timestamp = SystemTime::now();
 
-        /*// Update the contact.
-        let to = match self.contact_manager.get_contact(&service_id) {
-            Err(_) => {
-                self.add_contact(alias, &service_id)
-                    .await
-                    .expect("Can add contact that does not exist yet");
-
-                let device_ids = self.get_new_device_ids(&service_id).await?;
-
-                self.update_contact(alias, device_ids).await?;
-
-                self.contact_manager
-                    .get_contact(&service_id)
-                    .expect("Can get contact")
-            }
-            Ok(contact) => contact,
-        };*/
-
         let msgs = encrypt(
             &mut self.storage.protocol_store.identity_key_store,
             &mut self.storage.protocol_store.session_store,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -89,7 +89,7 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
         phone_number: String,
         database_url: &str,
         server_url: &str,
-        cert_path: &str,
+        cert_path: &Option<String>,
     ) -> Result<Client<Device, SignalServer>> {
         let mut csprng = OsRng;
         let aci_registration_id = OsRng.gen_range(1..16383);
@@ -214,7 +214,7 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
 
     pub async fn login(
         database_url: &str,
-        cert_path: &str,
+        cert_path: &Option<String>,
         server_url: &str,
     ) -> Result<Client<Device, SignalServer>> {
         let pool = Client::<T, U>::connect_to_db(database_url, false).await?;
@@ -249,6 +249,10 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
             KeyManager::new(signed + 1, kyber + 1, one_time + 1), // Adds 1 to prevent reusing key ids
             Storage::new(device.clone(), ProtocolStore::new(device.clone())),
         ))
+    }
+
+    pub async fn disconnect(&mut self){
+        self.server_api.disconnect().await;
     }
 
     pub async fn send_message(
@@ -501,6 +505,9 @@ impl<T: ClientDB, U: SignalServerAPI> Client<T, U> {
         Ok(device_ids)
     }
 }
+
+
+
 
 fn decode_ciphertext(
     bytes: Vec<u8>,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -44,9 +44,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
         rustls::crypto::ring::default_provider()
             .install_default()
             .expect("Failed to install rustls crypto provider");
-        (Some(var("CERT_PATH").expect("Could not find CERT_PATH")), var("HTTPS_SERVER_URL").expect("Could not find SERVER_URL"))
+        (
+            Some(var("CERT_PATH").expect("Could not find CERT_PATH")),
+            var("HTTPS_SERVER_URL").expect("Could not find SERVER_URL"),
+        )
     } else {
-        (None, var("HTTP_SERVER_URL").expect("Could not find SERVER_URL"))
+        (
+            None,
+            var("HTTP_SERVER_URL").expect("Could not find SERVER_URL"),
+        )
     };
 
     let mut alice = if Path::exists(Path::new(&alice_path)) {
@@ -57,7 +63,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             "123456789".into(),
             &alice_db_url,
             &server_url,
-            &cert_path
+            &cert_path,
         )
         .await?
     };
@@ -118,7 +124,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Ok(message) => println!("{message}"),
         Err(err) => println!("{:?}", err),
     }
-
 
     alice.disconnect().await;
     bob.disconnect().await;

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -81,13 +81,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await?
     };
 
-    alice.add_contact("bob", &bob.aci.into()).await.expect("No bob?");
-    bob.add_contact("alice", &alice.aci.into()).await.expect("No alice?");
+    alice
+        .add_contact("bob", &bob.aci.into())
+        .await
+        .expect("No bob?");
+    bob.add_contact("alice", &alice.aci.into())
+        .await
+        .expect("No alice?");
 
     // 1st message
-    alice
-        .send_message("Hello Bob!", "bob")
-        .await?;
+    alice.send_message("Hello Bob!", "bob").await?;
 
     let message_from_alice = bob.receive_message().await;
 
@@ -96,8 +99,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Err(err) => println!("{:?}", err),
     }
 
-    bob.send_message("Hello Alice!", "alice")
-        .await?;
+    bob.send_message("Hello Alice!", "alice").await?;
 
     let message_from_bob = alice.receive_message().await;
 
@@ -107,9 +109,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // 2nd message
-    alice
-        .send_message("Hello Bob again!", "bob")
-        .await?;
+    alice.send_message("Hello Bob again!", "bob").await?;
 
     let message_from_alice = bob.receive_message().await;
 
@@ -118,8 +118,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Err(err) => println!("{:?}", err),
     }
 
-    bob.send_message("Hello Alice again!",  "alice")
-        .await?;
+    bob.send_message("Hello Alice again!", "alice").await?;
 
     let message_from_bob = alice.receive_message().await;
 

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -81,9 +81,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await?
     };
 
+    alice.add_contact("bob", &bob.aci.into()).await.expect("No bob?");
+    bob.add_contact("alice", &alice.aci.into()).await.expect("No alice?");
+
     // 1st message
     alice
-        .send_message("Hello Bob!", &bob.aci.into(), "bob")
+        .send_message("Hello Bob!", "bob")
         .await?;
 
     let message_from_alice = bob.receive_message().await;
@@ -93,7 +96,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Err(err) => println!("{:?}", err),
     }
 
-    bob.send_message("Hello Alice!", &alice.aci.into(), "alice")
+    bob.send_message("Hello Alice!", "alice")
         .await?;
 
     let message_from_bob = alice.receive_message().await;
@@ -105,7 +108,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // 2nd message
     alice
-        .send_message("Hello Bob again!", &bob.aci.into(), "bob")
+        .send_message("Hello Bob again!", "bob")
         .await?;
 
     let message_from_alice = bob.receive_message().await;
@@ -115,7 +118,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Err(err) => println!("{:?}", err),
     }
 
-    bob.send_message("Hello Alice again!", &alice.aci.into(), "alice")
+    bob.send_message("Hello Alice again!",  "alice")
         .await?;
 
     let message_from_bob = alice.receive_message().await;

--- a/client/src/server.rs
+++ b/client/src/server.rs
@@ -19,13 +19,13 @@ use http_client::h1::H1Client;
 use libsignal_core::{Aci, DeviceId, ServiceId};
 use libsignal_protocol::PreKeyBundle;
 use serde_json::{from_slice, to_vec};
-use surf::middleware::{Middleware, Next};
 use std::error::Error;
 use std::fmt::Display;
+use std::io::Read;
 use std::{fmt::Debug, fs, sync::Arc, time::Duration};
+use surf::middleware::{Middleware, Next};
 use surf::{http::convert::json, Client, Config, Url};
 use surf::{Request, Response, StatusCode};
-use std::io::Read;
 
 const REGISTER_URI: &str = "v1/registration";
 const MSG_URI: &str = "/v1/messages";
@@ -146,7 +146,7 @@ impl SignalServerAPI for SignalServer {
             .map_err(SignalClientError::WebSocketError)?;
         Ok(())
     }
-    async fn disconnect(&mut self){
+    async fn disconnect(&mut self) {
         self.socket_manager.close().await;
     }
 
@@ -271,7 +271,7 @@ impl SignalServerAPI for SignalServer {
 struct SignalLayer;
 
 #[surf::utils::async_trait]
-impl Middleware for SignalLayer{
+impl Middleware for SignalLayer {
     async fn handle(
         &self,
         mut req: Request,
@@ -281,7 +281,7 @@ impl Middleware for SignalLayer{
         req.append_header("user-agent", "Signal Client Clone");
         req.append_header("x-signal-agent", "OWA");
         req.append_header("accept-encoding", "gzip");
-        
+
         let mut res = next.run(req, client).await?;
         if let Some(encoding) = res.header("Content-Encoding") {
             if encoding.iter().all(|x| x.as_str() == "gzip") {
@@ -306,13 +306,13 @@ impl SignalServer {
         } else {
             None
         };
-        
+
         let http_client: H1Client = http_client::Config::new()
             .set_timeout(Some(Duration::from_secs(5)))
             .set_tls_config(tls_config)
             .try_into()
             .expect("Could not create HTTP client");
-        
+
         let http_client: Client = Config::new()
             .set_http_client(http_client)
             .set_base_url(Url::parse(server_url).expect("Could not parse URL for server"))

--- a/client/src/server.rs
+++ b/client/src/server.rs
@@ -231,7 +231,16 @@ impl SignalServerAPI for SignalServer {
         let id = self.socket_manager.next_id();
         let response = self
             .socket_manager
-            .send(id, create_request(id, "PUT", &uri, vec![], Some(payload)))
+            .send(
+                id,
+                create_request(
+                    id,
+                    "PUT",
+                    &uri,
+                    vec!["content-type:application/json".to_string()],
+                    Some(payload),
+                ),
+            )
             .await
             .map_err(SendMessageError::WebSocketError)?;
 

--- a/client/src/socket_manager.rs
+++ b/client/src/socket_manager.rs
@@ -113,18 +113,26 @@ pub async fn signal_ws_connect(
     // TODO: do some smarter header handling than this, now both middleware and this defines headers
     // Create Signal auth
     let headers = [
-        ("Authorization", format!("Basic {}", BASE64_STANDARD.encode(format!("{}:{}", username, password)))),
+        (
+            "Authorization",
+            format!(
+                "Basic {}",
+                BASE64_STANDARD.encode(format!("{}:{}", username, password))
+            ),
+        ),
         ("Accept-Encoding", "gzip".to_string()),
         ("user-agent", "Signal Clone Client".to_string()),
         ("x-signal-agent", "OWA".to_string()),
         ("sec-websocket-extensions", "permessage-deflate".to_string()), // TODO: does not actually support this: https://github.com/snapview/tungstenite-rs/pull/426
-        ("x-signal-receive-stories", "false".to_string())
+        ("x-signal-receive-stories", "false".to_string()),
     ];
 
     for (key, value) in headers.iter() {
         req.headers_mut().insert(
             *key,
-            value.parse().map_err(|_| format!("failed to add {} header", key))?,
+            value
+                .parse()
+                .map_err(|_| format!("failed to add {} header", key))?,
         );
     }
 
@@ -143,8 +151,8 @@ pub async fn signal_ws_connect(
             .set_tcp_keepalive(&keepalive)
             .map_err(|_| "Failed to set keepalive".to_string())?;
     }
-    
-    let connector = if let Some(path) = tls_cert{
+
+    let connector = if let Some(path) = tls_cert {
         let tls_cfg = rustls_cfg(path)?;
         Some(Connector::Rustls(Arc::new(tls_cfg)))
     } else {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,7 +18,7 @@ rand = "0.8.5"
 redis = "0.27.4"
 deadpool-redis = "0.18.0"
 uuid = { version = "1.10.0", features = ["v4"] }
-tower-http = { version = "0.6.1", features = ["cors", "trace"] }
+tower-http = { version = "0.6.1", features = ["cors", "trace", "compression-gzip"] }
 sha2 = "0.10"
 hex = "0.4.3"
 sqlx = { version = "0.8.2", features = ["runtime-tokio-rustls", "postgres", "macros"] }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 mod account;
 mod account_authenticator;
 pub mod database;
@@ -15,11 +17,7 @@ mod validators;
 
 #[tokio::main]
 pub async fn main() {
-    //Starting logger
-    /*tracing_subscriber::fmt()
-    .log_internal_errors(true)
-    .with_max_level(tracing::Level::DEBUG)
-    .with_line_number(true)
-    .init();*/
-    server::start_server().await.unwrap();
+    let use_tls = !env::args().any(|arg| arg == "--no-tls");
+    println!("Using tls: {}", use_tls);
+    server::start_server(use_tls).await.unwrap();
 }

--- a/server/src/managers/websocket/connection.rs
+++ b/server/src/managers/websocket/connection.rs
@@ -132,7 +132,7 @@ impl<W: WSStream<Message, Error> + Debug + Send + 'static, DB: SignalDatabase + 
 
     pub async fn close(&mut self) {
         if let ConnectionState::Active(ref mut socket) = self.ws {
-            if let Err(e) = socket.close().await{
+            if let Err(e) = socket.close().await {
                 println!("WebSocketConnection ERROR: {e}");
             }
         }

--- a/server/src/managers/websocket/connection.rs
+++ b/server/src/managers/websocket/connection.rs
@@ -114,7 +114,8 @@ impl<W: WSStream<Message, Error> + Debug + Send + 'static, DB: SignalDatabase + 
         mut message: Envelope,
     ) -> Result<WebSocketMessage, SystemTimeError> {
         let id = generate_req_id();
-        message.ephemeral = Some(false);
+        message.ephemeral = None; // was false
+        message.story = Some(false); // TODO: needs to handled in handle_request instead
         let msg = create_request(
             id,
             "PUT",
@@ -421,6 +422,7 @@ pub(crate) mod test {
     use common::signalservice::{Envelope, WebSocketMessage, WebSocketRequestMessage};
     use common::websocket::net_helper::{create_request, create_response};
     use futures_util::{stream::SplitStream, StreamExt};
+    use hmac::digest::consts::False;
     use libsignal_core::Aci;
     use prost::{bytes::Bytes, Message as PMessage};
 
@@ -431,7 +433,8 @@ pub(crate) mod test {
 
     fn make_envelope() -> Envelope {
         Envelope {
-            ephemeral: Some(false),
+            ephemeral: None,
+            story: Some(false),
             content: Some("Hello".as_bytes().to_vec()),
             ..Default::default()
         }

--- a/server/src/managers/websocket/websocket_manager.rs
+++ b/server/src/managers/websocket/websocket_manager.rs
@@ -113,7 +113,6 @@ where
                         println!("sent!");
                     }
                     Message::Close(_) => {
-                        connection.lock().await.close().await;
                         break;
                     }
                     _ => {}


### PR DESCRIPTION
I have added:
- TLS flag for ease of analysis
- disconnect method to client struct in client code
   - server will no longer complain about clients disconnection without saying goodbye
- Signal layer for client for manual gzip decompression and signal headers
- Signal headers for websocket on client
  - needs to be refactored when this [feature](https://github.com/snapview/tungstenite-rs/pull/426) has been implemented.
- signal timestamp on server
- more accurate CORS
- Changed ports to actual http/s ports, linux users can just change them if they dont want to sudo


closes #182, closes #184, closes #189